### PR TITLE
Fix various build errors

### DIFF
--- a/bench/tcp/LibUV.hs
+++ b/bench/tcp/LibUV.hs
@@ -3,7 +3,7 @@
 
 module Main where
 
-import System.IO.Net
+import System.IO.TCP
 import System.IO.Buffered
 import Control.Concurrent
 import Foreign.ForeignPtr

--- a/bench/tcp/MIO.hs
+++ b/bench/tcp/MIO.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 module Main where
 

--- a/bench/tcp/tcp.cabal
+++ b/bench/tcp/tcp.cabal
@@ -18,7 +18,7 @@ cabal-version:       >=1.10
 executable libuv
   main-is:             LibUV.hs
   other-modules:        System.IO.Buffered
-                        System.IO.Net
+                        System.IO.TCP
                         System.IO.Net.SockAddr
                         System.IO.UV.Exception
                         System.IO.UV.Internal

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,5 +2,5 @@ resolver: lts-10.4
 
 packages:
 - .
-- bench\tcp
-- bench\timers
+- bench/tcp
+- bench/timers

--- a/stdio.cabal
+++ b/stdio.cabal
@@ -13,8 +13,8 @@ maintainer:          drkoster@qq.com
 category:            Data
 build-type:          Simple
 cabal-version:       >=1.10
-homepage:            https://github.com/winterland1989/stdio
-bug-reports:         https://github.com/winterland1989/stdio/issues
+homepage:            https://github.com/haskell-stdio/stdio
+bug-reports:         https://github.com/haskell-stdio/stdio/issues
 
 extra-source-files:  ChangeLog.md
                      include/hs_uv.h
@@ -23,7 +23,7 @@ extra-source-files:  ChangeLog.md
 
 source-repository head
   type:     git
-  location: git://github.com/winterland1989/stdio.git
+  location: git://github.com/haskell-stdio/stdio.git
 
 
 library


### PR DESCRIPTION
- The paths in `stack.yaml` where using backwards slashes. This caused the following error when running stack on a linux machine:
  `.../bench\tcp/: getDirectoryContents:openDirStream: does not exist (No such file or directory)` 
- There where some references to `System.IO.Net`, which was renamed to `System.IO.TCP` in 4b8ec2fe9a29827d281c7d0b20b21b067979afda
- Not an error, but the links in the cabal file where outdated.