### PR TITLE
Basic filesystem operations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install:
  - travis_retry sudo add-apt-repository -y ppa:hvr/ghc
  - travis_retry sudo apt-get update
  - travis_retry sudo apt-get install cabal-install-$CABALVER ghc-$GHCVER # see note about happy/alex
- - git clone https://github.com/libuv/libuv.git && cd libuv && git checkout tags/v1.8.0 && sh autogen.sh && ./configure && make && sudo make install && cd ..
+ - git clone https://github.com/libuv/libuv.git && cd libuv && git checkout tags/v1.11.0 && sh autogen.sh && ./configure && make && sudo make install && cd ..
  - export PATH=/usr/local/lib:$PATH
  - export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
  - export EXTRA_OPT="--extra-lib-dirs=/usr/local/include --extra-lib-dirs=/usr/local/lib"

--- a/System/IO/FileSystem.hs
+++ b/System/IO/FileSystem.hs
@@ -38,6 +38,7 @@ import Control.Monad.IO.Class
 import Data.Word (Word8)
 import System.IO (FilePath)
 import System.IO.Exception
+import System.IO.Resource
 import System.IO.UV.Manager
 import System.IO.UV.Internal
 import Foreign.Marshal.Alloc

--- a/System/IO/FileSystem.hs
+++ b/System/IO/FileSystem.hs
@@ -28,6 +28,7 @@ module System.IO.FileSystem
   , open
   , read
   , readT
+  , write
   ) where
 
 import Prelude hiding (read)
@@ -35,6 +36,7 @@ import Prelude hiding (read)
 import Control.Monad (void)
 import Control.Monad.IO.Class
 import Data.Word (Word8)
+import System.IO (FilePath)
 import System.IO.Exception
 import System.IO.UV.Manager
 import System.IO.UV.Internal
@@ -51,7 +53,7 @@ defaultMode = 0o666
 
 -- | Open a file and get the descriptor
 open :: HasCallStack
-     => String
+     => FilePath
      -> UVFileFlag
      -> UVFileMode
      -- ^ Sets the file mode (permission and sticky bits),
@@ -90,6 +92,17 @@ readT mgr fd size offset = do
     liftIO $ withUVManager mgr $ \loop ->
         throwUVIfMinus_ $ hs_uv_fs_read_threaded loop req fd buf size' offset'
     return (req, buf)
+
+-- | Read a file, non-threaded version
+write :: UVFD
+      -> Ptr Word8
+      -> Int
+      -> Int
+      -> IO ()
+write fd buf size offset = do
+    let size' = fromIntegral size
+        offset' = fromIntegral offset
+    throwUVIfMinus_ $ hs_uv_fs_write fd buf size' offset'
 
 {-
 

--- a/System/IO/FileSystem.hs
+++ b/System/IO/FileSystem.hs
@@ -21,43 +21,81 @@ Otherwise you may block RTS's capability thus all the other threads live on it.
 -}
 
 module System.IO.FileSystem
-  ( scandir
-  , scandirT
+  ( UVFileFlag(..)
+  , UVFileMode
+  , defaultMode
+  -- * Operations
+  , open
+  , read
+  , readT
   ) where
 
+import Prelude hiding (read)
+
+import Control.Monad (void)
+import Control.Monad.IO.Class
+import Data.Word (Word8)
 import System.IO.Exception
 import System.IO.UV.Manager
 import System.IO.UV.Internal
-import System.IO.UV.Exception
-import Control.Concurrent
+import Foreign.Marshal.Alloc
 import Foreign.Ptr
 import Foreign.C
-import Data.CBytes
-import GHC.Generics
 
 --------------------------------------------------------------------------------
 -- File
+
+-- | default mode for open, 0o666(readable and writable).
+defaultMode :: UVFileMode
+defaultMode = 0o666
+
+open :: HasCallStack
+     => String
+     -> UVFileFlag
+     -> UVFileMode
+     -- ^ Sets the file mode (permission and sticky bits),
+     -- but only if the file was created, see 'defaultMode'.
+     -> Resource UVFD
+open path flags mode = do
+    path' <- initResource (newCString path) free
+    initResource
+        (hs_uv_fs_open path' flags mode)
+        (void . hs_uv_fs_close)
+
+read :: UVFD
+     -> Int
+     -> Int
+     -> Resource (Ptr Word8)
+read fd size offset = do
+    let size' = fromIntegral size
+        offset' = fromIntegral offset
+    buf <- initResource (mallocBytes size :: IO (Ptr Word8)) free
+    liftIO $ throwUVIfMinus_ $ hs_uv_fs_read fd buf size' offset'
+    return buf
+
+readT :: UVManager
+      -> UVFD
+      -> Int
+      -> Int
+      -> Resource (Ptr UVFSReq, Ptr Word8)
+readT mgr fd size offset = do
+    let size' = fromIntegral size
+        offset' = fromIntegral offset
+    req <- initUVFS (\_ _ _ -> return ()) mgr
+    buf <- initResource (mallocBytes size :: IO (Ptr Word8)) free
+    liftIO $ withUVManager mgr $ \loop ->
+        throwUVIfMinus_ $ hs_uv_fs_read_threaded loop req fd buf size' offset'
+    return (req, buf)
+
+{-
 
 data UVFile = UVFile
     { uvFileFd     :: {-# UNPACK #-} UVFD
     , uvFileReq    :: {-# UNPACK #-} UVReq
     , uvFileSlot   :: {-# UNPACK #-} Int
-    , uvFileReadOffset ::
     }
 
 newtype UVFileT = UVFileT { uvFile :: UVFile }
-
-open :: HasCallStack
-     => CByte
-     -> UVFileFlag
-     -> CInt    -- sets the file mode (permission and sticky bits), but only if the file was created, see 'defaultMode'.
-     -> Resource UVFile
-open = --
-
--- | default mode for open, 0o666(readable and writable).
-defaultMode :: CInt
-defaultMode = 0o666
-
 
 --------------------------------------------------------------------------------
 --
@@ -116,4 +154,4 @@ loopScanDirReq req = do
                 !path' <- fromCString path
                 !rest <- loopScanDirReq req
                 return ((path', typ') : rest)
-
+-}

--- a/System/IO/FileSystem.hs
+++ b/System/IO/FileSystem.hs
@@ -45,10 +45,11 @@ import Foreign.C
 --------------------------------------------------------------------------------
 -- File
 
--- | default mode for open, 0o666(readable and writable).
+-- | Default mode for open, 0o666(readable and writable).
 defaultMode :: UVFileMode
 defaultMode = 0o666
 
+-- | Open a file and get the descriptor
 open :: HasCallStack
      => String
      -> UVFileFlag
@@ -62,6 +63,7 @@ open path flags mode = do
         (hs_uv_fs_open path' flags mode)
         (void . hs_uv_fs_close)
 
+-- | Read a file, non-threaded version
 read :: UVFD
      -> Int
      -> Int
@@ -73,6 +75,8 @@ read fd size offset = do
     liftIO $ throwUVIfMinus_ $ hs_uv_fs_read fd buf size' offset'
     return buf
 
+-- | Read a file, threaded version
+-- The buffer shouldn't be read before the request is completed
 readT :: UVManager
       -> UVFD
       -> Int

--- a/System/IO/UV/Internal.hsc
+++ b/System/IO/UV/Internal.hsc
@@ -195,9 +195,14 @@ foreign import ccall unsafe uv_tty_init :: Ptr UVLoop -> Ptr UVHandle -> CInt ->
 --------------------------------------------------------------------------------
 -- fs
 
-foreign import ccall uv_fs_req_cleanup :: Ptr UVReq -> IO () 
+data UVFSReq
 
-type UVFSCallBack = FunPtr (Ptr UVReq -> IO ())
+peekUVFSReqResult :: Ptr UVFSReq -> IO CInt
+peekUVFSReqResult p = fromIntegral <$> (#{peek uv_fs_t, result} p :: IO CSize)
+
+foreign import ccall uv_fs_req_cleanup :: Ptr UVFSReq -> IO () 
+
+type UVFSCallBack = FunPtr (Ptr UVFSReq -> IO ())
 
 foreign import ccall "hs_uv.h &hs_uv_fs_callback" uvFSCallBack :: UVFSCallBack
 
@@ -214,11 +219,9 @@ foreign import ccall unsafe hs_uv_fs_unlink :: CString -> IO CInt
 foreign import ccall unsafe hs_uv_fs_mkdir :: CString -> UVFileMode -> IO CInt
 
 -- threaded functions
-foreign import ccall unsafe hs_uv_fs_free :: Ptr UVReq -> IO ()
-foreign import ccall unsafe hs_uv_fs_alloc :: Ptr UVLoop -> IO (Ptr UVReq)
-foreign import ccall unsafe hs_uv_fs_close_threaded :: Ptr UVLoop -> Ptr UVReq -> UVFD -> IO CInt
+foreign import ccall unsafe hs_uv_fs_close_threaded :: Ptr UVLoop -> Ptr UVFSReq -> UVFD -> IO CInt
 foreign import ccall unsafe hs_uv_fs_read_threaded
-  :: Ptr UVLoop -> Ptr UVReq -> UVFD -> Ptr Word8 -> CInt -> CInt -> UVFSCallBack -> IO CInt
+  :: Ptr UVLoop -> Ptr UVFSReq -> UVFD -> Ptr Word8 -> CInt -> CInt -> IO CInt
 
 #{enum UVFileFlag, UVFileFlag,
     uV_FS_O_APPEND       = UV_FS_O_APPEND,

--- a/System/IO/UV/Internal.hsc
+++ b/System/IO/UV/Internal.hsc
@@ -195,8 +195,12 @@ foreign import ccall unsafe uv_tty_init :: Ptr UVLoop -> Ptr UVHandle -> CInt ->
 --------------------------------------------------------------------------------
 -- fs
 
+-- | FileSystem request. Casteable to `UVReq`.
 data UVFSReq
 
+-- | Result of the request. < 0 means error, success otherwise.
+-- On requests such as reads and writes it indicates
+-- the amount of data that was read or written, respectively.
 peekUVFSReqResult :: Ptr UVFSReq -> IO CInt
 peekUVFSReqResult p = fromIntegral <$> (#{peek uv_fs_t, result} p :: IO CSize)
 

--- a/System/IO/UV/Internal.hsc
+++ b/System/IO/UV/Internal.hsc
@@ -201,8 +201,24 @@ type UVFSCallBack = FunPtr (Ptr UVReq -> IO ())
 
 foreign import ccall "hs_uv.h &hs_uv_fs_callback" uvFSCallBack :: UVFSCallBack
 
+type UVFileMode = Int32
 newtype UVFileFlag = UVFileFlag CInt
     deriving (Bounded, Enum, Eq, Integral, Num, Ord, Read, Real, Show, FiniteBits, Bits, Storable)
+
+-- non-threaded functions
+foreign import ccall unsafe hs_uv_fs_open :: CString -> UVFileFlag -> UVFileMode -> IO UVFD
+foreign import ccall unsafe hs_uv_fs_close :: UVFD -> IO CInt
+foreign import ccall unsafe hs_uv_fs_read :: UVFD -> Ptr Word8 -> CInt -> CInt -> IO CInt
+foreign import ccall unsafe hs_uv_fs_write :: UVFD -> Ptr Word8 -> CInt -> CInt -> IO CInt
+foreign import ccall unsafe hs_uv_fs_unlink :: CString -> IO CInt
+foreign import ccall unsafe hs_uv_fs_mkdir :: CString -> UVFileMode -> IO CInt
+
+-- threaded functions
+foreign import ccall unsafe hs_uv_fs_free :: Ptr UVReq -> IO ()
+foreign import ccall unsafe hs_uv_fs_alloc :: Ptr UVLoop -> IO (Ptr UVReq)
+foreign import ccall unsafe hs_uv_fs_close_threaded :: Ptr UVLoop -> Ptr UVReq -> UVFD -> IO CInt
+foreign import ccall unsafe hs_uv_fs_read_threaded
+  :: Ptr UVLoop -> Ptr UVReq -> UVFD -> Ptr Word8 -> CInt -> CInt -> UVFSCallBack -> IO CInt
 
 #{enum UVFileFlag, UVFileFlag,
     uV_FS_O_APPEND       = UV_FS_O_APPEND,

--- a/cbits/hs_uv.c
+++ b/cbits/hs_uv.c
@@ -605,27 +605,19 @@ int hs_uv_fs_mkdir(char* path, int mode){
 }
 
 // fs, thread pool version
-void hs_uv_fs_free(uv_fs_t* req){
-    hs_uv_req_free((uv_req_t*)req, req->loop);
-}
-
-uv_fs_t* hs_uv_fs_alloc(uv_loop_t* loop){
-    return (uv_fs_t*)hs_uv_req_alloc(UV_FS, loop);
-}
-
 int hs_uv_fs_close_threaded(uv_loop_t* loop, uv_fs_t* req, int32_t file){
     // do the last clean up, since uv_fs_req_cleanup is idempotent
     uv_fs_req_cleanup(req);
-    return uv_fs_close(loop, req, (uv_file)file, hs_uv_fs_free);
+    return uv_fs_close(loop, req, (uv_file)file, (uv_fs_cb)hs_uv_req_free);
 }
 
 int hs_uv_fs_read_threaded(uv_loop_t* loop, uv_fs_t* req, int32_t file,
-        char* buf, size_t buf_siz, int64_t offset, uv_fs_cb cb){
+        char* buf, size_t buf_siz, int64_t offset){
     uv_buf_t buf_t = { 
         .base = buf,
         .len = buf_siz
     };
-    uv_fs_read(loop, req, (uv_file)file, &buf_t, 1, offset, cb);
+    uv_fs_read(loop, req, (uv_file)file, &buf_t, 1, offset, hs_uv_fs_callback);
 }
 
 uv_dirent_t* hs_uv_dirent_alloc(){
@@ -637,7 +629,10 @@ void hs_uv_dirent_free(uv_dirent_t* ent){
 }
 
 void hs_uv_fs_callback(uv_fs_t* req){
+    size_t slot = (size_t)req->data;
     hs_loop_data* loop_data = req->loop->data;
-    loop_data->event_queue[loop_data->event_counter] = (size_t)req->data; // push the slot to event queue
+
+    assert(loop_data->event_counter < loop_data->size);
+    loop_data->event_queue[loop_data->event_counter] = slot; // push the slot to event queue
     loop_data->event_counter += 1;
 }

--- a/cbits/hs_uv.c
+++ b/cbits/hs_uv.c
@@ -603,28 +603,23 @@ int hs_uv_fs_mkdir(char* path, int mode){
     uv_fs_t req;
     return uv_fs_mkdir(NULL, &req, path, mode, NULL);
 }
-/*
+
 // fs, thread pool version
 void hs_uv_fs_free(uv_fs_t* req){
-    size_t slot = req->data;
-    free_slot(req->loop, slot);
-    free(req);
+    hs_uv_req_free((uv_req_t*)req, req->loop);
 }
-uv_fs_t* hs_uv_fs_alloc(){
-    uv_req_t* req = malloc(uv_req_size(UV_FS));
-    if (req == NULL) { return NULL; }
-    else {
-        req->data = (void*)alloc_slot(loop);
-        return req;
-    }
+
+uv_fs_t* hs_uv_fs_alloc(uv_loop_t* loop){
+    return (uv_fs_t*)hs_uv_req_alloc(UV_FS, loop);
 }
-int hs_uv_fs_close(uv_loop_t* loop, uv_fs_t* req, int32_t file){
+
+int hs_uv_fs_close_threaded(uv_loop_t* loop, uv_fs_t* req, int32_t file){
     // do the last clean up, since uv_fs_req_cleanup is idempotent
     uv_fs_req_cleanup(req);
     return uv_fs_close(loop, req, (uv_file)file, hs_uv_fs_free);
 }
 
-int hs_uv_fs_read(uv_loop_t* loop, uv_fs_t* req, int32_t file, 
+int hs_uv_fs_read_threaded(uv_loop_t* loop, uv_fs_t* req, int32_t file,
         char* buf, size_t buf_siz, int64_t offset, uv_fs_cb cb){
     uv_buf_t buf_t = { 
         .base = buf,
@@ -632,7 +627,7 @@ int hs_uv_fs_read(uv_loop_t* loop, uv_fs_t* req, int32_t file,
     };
     uv_fs_read(loop, req, (uv_file)file, &buf_t, 1, offset, cb);
 }
-*/
+
 uv_dirent_t* hs_uv_dirent_alloc(){
     return malloc(sizeof(uv_dirent_t));
 }

--- a/cbits/hs_uv.c
+++ b/cbits/hs_uv.c
@@ -629,10 +629,8 @@ void hs_uv_dirent_free(uv_dirent_t* ent){
 }
 
 void hs_uv_fs_callback(uv_fs_t* req){
-    size_t slot = (size_t)req->data;
     hs_loop_data* loop_data = req->loop->data;
-
     assert(loop_data->event_counter < loop_data->size);
-    loop_data->event_queue[loop_data->event_counter] = slot; // push the slot to event queue
+    loop_data->event_queue[loop_data->event_counter] = (size_t)req->data; // push the slot to event queue
     loop_data->event_counter += 1;
 }

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,6 +3,7 @@ resolver: lts-10.4
 extra-deps:
 - primitive-0.6.4.0
 - exceptions-0.10.0
+- tasty-1.1.0.1
 
 packages:
 - .

--- a/stdio.cabal
+++ b/stdio.cabal
@@ -59,7 +59,7 @@ library
                             System.IO.TTY
                             -- System.IO.Log
 
-                            -- System.IO.FileSystem
+                            System.IO.FileSystem
 
                             System.IO.TCP
                             System.IO.Net.SockAddr

--- a/stdio.cabal
+++ b/stdio.cabal
@@ -162,7 +162,11 @@ benchmark bench
 test-suite test
     type: exitcode-stdio-1.0
     main-is: Main.hs
-    -- other-modules:      
+    other-modules:          Property.Text
+                            Property.Vector
+                            Unit.FileSystem
+                            Unit.LowResTimer
+                            Unit.Resource
     hs-source-dirs: test
     build-depends:  stdio
                   , base
@@ -172,6 +176,7 @@ test-suite test
                   , tasty-hunit
                   , QuickCheck >= 2.10
                   , async
+                  , temporary
                   , unboxed-ref
 
 

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -5,6 +5,7 @@ module Main where
 import           Test.Tasty
 import           Property.Vector
 import           Property.Text
+import           Unit.FileSystem
 import           Unit.LowResTimer
 import           Unit.Resource
 
@@ -14,6 +15,6 @@ main = defaultMain $ testGroup "stdio tests" [
     ,   propertyText
     ,   unitLowResTimer
     ,   unitResource
-
+    ,   unitFileSystem
     ]
 

--- a/test/Unit/FileSystem.hs
+++ b/test/Unit/FileSystem.hs
@@ -1,0 +1,67 @@
+module Unit.FileSystem where
+
+import Data.Char (chr, ord)
+import Test.Tasty hiding (withResource)
+import Test.Tasty.HUnit
+import Control.Concurrent.MVar (readMVar)
+import Foreign.Marshal.Array
+import Foreign.Ptr
+import System.IO.Exception
+import System.IO.FileSystem as FS
+import System.IO.Resource
+import System.IO.Temp
+import System.IO.UV.Manager
+import System.IO.UV.Internal
+
+unitFileSystem :: TestTree
+unitFileSystem = testGroup "filesystem operations" [
+        testCase "Opens and writes a file" $ do
+            
+            let flags = uV_FS_O_RDWR
+                mode = defaultMode
+                content = "Hello world!"
+                size = length content
+            filename <- emptySystemTempFile "stdio-unit"
+
+            withResource (open filename flags mode) $ \fd ->
+                withArray (map (fromIntegral . ord) content) $ \buf ->
+                    write fd buf size 0
+
+            written <- readFile filename
+            written @=? content
+
+    ,   testCase "Reads a file" $ do
+
+            let flags = uV_FS_O_RDWR
+                mode = defaultMode
+                content = "Hello world!"
+                size = length content
+            filename <- writeSystemTempFile "stdio-unit" content
+
+            withResource (open filename flags mode) $ \fd ->
+                withResource (FS.read fd size 0) $ \buf -> do
+                    res <- map (chr . fromIntegral) <$> peekArray size buf
+                    res @=? content
+
+    ,   testCase "Reads a using the threaded version" $ do
+
+            let flags = uV_FS_O_RDONLY
+                mode = defaultMode
+                content = "Hello world!"
+                size = length content
+            filename <- writeSystemTempFile "stdio-unit" content
+
+            uvm <- getUVManager
+
+            withResource (open filename flags mode) $ \fd ->
+                withResource (readT uvm fd size 0) $ \(req, buf) -> do
+                    slot <- peekUVReqData $ castPtr req
+                    mvar <- withUVManager' uvm $ getBlockMVar uvm slot
+
+                    readMVar mvar
+                    readLength <- throwUVIfMinus $
+                        fromIntegral <$> peekUVFSReqResult req
+
+                    res <- map (chr . fromIntegral) <$> peekArray readLength buf
+                    res @=? content
+    ]


### PR DESCRIPTION
Adds a minimal set of operations to `System.IO.FileSystem`. Just `open`, `write`, `read`, and `readT` (threaded version).

I wanted an non-trivial operation from where I could get an `UVSlot` so I added these based on the functions already present in `hs_uv.c`.
I hope it is not too far away from the design you had in mind, just tell me what should be changed.