### PR TITLE
ByteString conversions

### DIFF
--- a/stdio.cabal
+++ b/stdio.cabal
@@ -201,6 +201,7 @@ library
                         ,   deepseq    >= 1.4 && < 1.5
                         ,   template-haskell == 2.14.*
                         ,   stm        == 2.5.*
+                        ,   bytestring == 0.10.*
 
   if flag(integer-simple)
     cpp-options: -DINTEGER_SIMPLE

--- a/test/Std/Data/Vector/BaseSpec.hs
+++ b/test/Std/Data/Vector/BaseSpec.hs
@@ -8,6 +8,7 @@ import qualified Data.List                as List
 import           Data.Word
 import           Data.Hashable            (hashWithSalt, hash)
 import qualified Std.Data.Vector.Base     as V
+import qualified Std.Foreign.PrimArray    as FP
 import           Test.QuickCheck
 import           Test.QuickCheck.Function
 import           Test.QuickCheck.Property
@@ -283,3 +284,9 @@ spec = describe "vector-base" $ do
             (V.elemIndex y . V.pack @V.PrimVector @Int $ x)  === (List.elemIndex y $ x)
         prop "vector elemIndex = List.elemIndex" $ \ y x ->
             (V.elemIndex y . V.pack @V.PrimVector @Word8 $ x)  === (List.elemIndex y $ x)
+
+    describe "vector ByteString roundtrip" $
+        prop "vector ByteString roundtrip" $ \ z -> ioProperty $ do
+            let bytes = V.pack @V.PrimVector @Word8 z
+            bytes' <- FP.bytesFromByteString =<< FP.bytesToByteString bytes
+            return $ bytes === bytes'


### PR DESCRIPTION
Added the ByteString conversions
I've slightly changed `bytesFromByteString`, I think it should be better now
Also, I've added it to `Std.Foreign.PrimArray`, because putting it in `Std.Vector.Base` would cause circular module dependencies, since `Std.Foreign.PrimArray` uses the vector modules.